### PR TITLE
Add base module tests (views) and refactor previous tests with short form of comparison (Nimble syntax's shoogar)

### DIFF
--- a/ShopApp.xcodeproj/project.pbxproj
+++ b/ShopApp.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		0B7CEFA5203C57BB00FAA32C /* BaseTableViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7CEFA4203C57BB00FAA32C /* BaseTableViewControllerSpec.swift */; };
 		0B7CEFA7203C59CE00FAA32C /* BaseCollectionViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7CEFA6203C59CE00FAA32C /* BaseCollectionViewControllerSpec.swift */; };
 		0B7CEFA9203C5E1E00FAA32C /* GridCollectionViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7CEFA8203C5E1E00FAA32C /* GridCollectionViewModelSpec.swift */; };
+		0B7CEFAD203C76FD00FAA32C /* ErrorViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7CEFAC203C76FD00FAA32C /* ErrorViewSpec.swift */; };
 		0B9426551FFE468100A986AB /* OrderHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9426541FFE468100A986AB /* OrderHeaderView.swift */; };
 		0B9426571FFE468C00A986AB /* OrderHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0B9426561FFE468C00A986AB /* OrderHeaderView.xib */; };
 		0B953D502020C4F500DD32DE /* HtmlStringMultimediaCompressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B953D4F2020C4F500DD32DE /* HtmlStringMultimediaCompressor.swift */; };
@@ -441,6 +442,7 @@
 		0B7CEFA4203C57BB00FAA32C /* BaseTableViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewControllerSpec.swift; sourceTree = "<group>"; };
 		0B7CEFA6203C59CE00FAA32C /* BaseCollectionViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionViewControllerSpec.swift; sourceTree = "<group>"; };
 		0B7CEFA8203C5E1E00FAA32C /* GridCollectionViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridCollectionViewModelSpec.swift; sourceTree = "<group>"; };
+		0B7CEFAC203C76FD00FAA32C /* ErrorViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewSpec.swift; sourceTree = "<group>"; };
 		0B9426541FFE468100A986AB /* OrderHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderHeaderView.swift; sourceTree = "<group>"; };
 		0B9426561FFE468C00A986AB /* OrderHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderHeaderView.xib; sourceTree = "<group>"; };
 		0B953D4F2020C4F500DD32DE /* HtmlStringMultimediaCompressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HtmlStringMultimediaCompressor.swift; sourceTree = "<group>"; };
@@ -1204,6 +1206,7 @@
 		0B7CEF97203C0DF100FAA32C /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				0B7CEFAC203C76FD00FAA32C /* ErrorViewSpec.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2664,6 +2667,7 @@
 				0B7CEF84203B1F8E00FAA32C /* AuthentificationRepositoryMock.swift in Sources */,
 				0B7CEFA9203C5E1E00FAA32C /* GridCollectionViewModelSpec.swift in Sources */,
 				0B7CEF9F203C0EB400FAA32C /* TabBarControllerSpec.swift in Sources */,
+				0B7CEFAD203C76FD00FAA32C /* ErrorViewSpec.swift in Sources */,
 				0B7CEF9B203C0E5500FAA32C /* BaseViewControllerSpec.swift in Sources */,
 				0B7CEFA7203C59CE00FAA32C /* BaseCollectionViewControllerSpec.swift in Sources */,
 				0B7CEF76203B155400FAA32C /* UpdateCustomerUseCaseMock.swift in Sources */,

--- a/ShopApp.xcodeproj/project.pbxproj
+++ b/ShopApp.xcodeproj/project.pbxproj
@@ -79,6 +79,8 @@
 		0B7CEFA7203C59CE00FAA32C /* BaseCollectionViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7CEFA6203C59CE00FAA32C /* BaseCollectionViewControllerSpec.swift */; };
 		0B7CEFA9203C5E1E00FAA32C /* GridCollectionViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7CEFA8203C5E1E00FAA32C /* GridCollectionViewModelSpec.swift */; };
 		0B7CEFAD203C76FD00FAA32C /* ErrorViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7CEFAC203C76FD00FAA32C /* ErrorViewSpec.swift */; };
+		0B902C7F203D61CE005B0A66 /* BasePickerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B902C7E203D61CE005B0A66 /* BasePickerSpec.swift */; };
+		0B902C82203D8DCD005B0A66 /* ErrorViewDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B902C81203D8DCD005B0A66 /* ErrorViewDelegateMock.swift */; };
 		0B9426551FFE468100A986AB /* OrderHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B9426541FFE468100A986AB /* OrderHeaderView.swift */; };
 		0B9426571FFE468C00A986AB /* OrderHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0B9426561FFE468C00A986AB /* OrderHeaderView.xib */; };
 		0B953D502020C4F500DD32DE /* HtmlStringMultimediaCompressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B953D4F2020C4F500DD32DE /* HtmlStringMultimediaCompressor.swift */; };
@@ -443,6 +445,8 @@
 		0B7CEFA6203C59CE00FAA32C /* BaseCollectionViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionViewControllerSpec.swift; sourceTree = "<group>"; };
 		0B7CEFA8203C5E1E00FAA32C /* GridCollectionViewModelSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridCollectionViewModelSpec.swift; sourceTree = "<group>"; };
 		0B7CEFAC203C76FD00FAA32C /* ErrorViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewSpec.swift; sourceTree = "<group>"; };
+		0B902C7E203D61CE005B0A66 /* BasePickerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePickerSpec.swift; sourceTree = "<group>"; };
+		0B902C81203D8DCD005B0A66 /* ErrorViewDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewDelegateMock.swift; sourceTree = "<group>"; };
 		0B9426541FFE468100A986AB /* OrderHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderHeaderView.swift; sourceTree = "<group>"; };
 		0B9426561FFE468C00A986AB /* OrderHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderHeaderView.xib; sourceTree = "<group>"; };
 		0B953D4F2020C4F500DD32DE /* HtmlStringMultimediaCompressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HtmlStringMultimediaCompressor.swift; sourceTree = "<group>"; };
@@ -1206,9 +1210,19 @@
 		0B7CEF97203C0DF100FAA32C /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				0B902C80203D8DC2005B0A66 /* Mocks */,
+				0B902C7E203D61CE005B0A66 /* BasePickerSpec.swift */,
 				0B7CEFAC203C76FD00FAA32C /* ErrorViewSpec.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		0B902C80203D8DC2005B0A66 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				0B902C81203D8DCD005B0A66 /* ErrorViewDelegateMock.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		0B9426521FFE461C00A986AB /* OrderHeaderView */ = {
@@ -2663,12 +2677,14 @@
 			files = (
 				0B7CEF9D203C0EA700FAA32C /* NavigationControllerSpec.swift in Sources */,
 				0B7CEF7F203B175600FAA32C /* ChangePasswordViewModelSpec.swift in Sources */,
+				0B902C82203D8DCD005B0A66 /* ErrorViewDelegateMock.swift in Sources */,
 				0B7CEFA5203C57BB00FAA32C /* BaseTableViewControllerSpec.swift in Sources */,
 				0B7CEF84203B1F8E00FAA32C /* AuthentificationRepositoryMock.swift in Sources */,
 				0B7CEFA9203C5E1E00FAA32C /* GridCollectionViewModelSpec.swift in Sources */,
 				0B7CEF9F203C0EB400FAA32C /* TabBarControllerSpec.swift in Sources */,
 				0B7CEFAD203C76FD00FAA32C /* ErrorViewSpec.swift in Sources */,
 				0B7CEF9B203C0E5500FAA32C /* BaseViewControllerSpec.swift in Sources */,
+				0B902C7F203D61CE005B0A66 /* BasePickerSpec.swift in Sources */,
 				0B7CEFA7203C59CE00FAA32C /* BaseCollectionViewControllerSpec.swift in Sources */,
 				0B7CEF76203B155400FAA32C /* UpdateCustomerUseCaseMock.swift in Sources */,
 				0B7CEF7D203B15DF00FAA32C /* ChangePasswordViewControllerSpec.swift in Sources */,

--- a/ShopApp/App/Modules/Base/Views/BasePicker/BasePicker.swift
+++ b/ShopApp/App/Modules/Base/Views/BasePicker/BasePicker.swift
@@ -8,14 +8,14 @@
 
 import UIKit
 
-private let kUnderlineViewAlphaDefault: CGFloat = 0.2
-private let kUnderlineViewAlphaHighlighted: CGFloat = 1
-private let kUnderlineViewHeightDefault: CGFloat = 1
-private let kUnderlineViewHeightHighlighted: CGFloat = 2
-
 class BasePicker: PlaceholderedTextField {
     @IBOutlet private weak var underlineView: UIView!
     @IBOutlet private weak var underlineViewHeight: NSLayoutConstraint!
+    
+    private let underlineViewAlphaDefault: CGFloat = 0.2
+    private let underlineViewAlphaHighlighted: CGFloat = 1
+    private let underlineViewHeightDefault: CGFloat = 1
+    private let underlineViewHeightHighlighted: CGFloat = 2
 
     var pickerView = UIPickerView()
     
@@ -73,7 +73,7 @@ class BasePicker: PlaceholderedTextField {
         textField.tintColor = .clear
         textField.inputView = pickerView
         placeholderLabel.text = initialPlaceholder.uppercased()
-        underlineView.alpha = kUnderlineViewAlphaDefault
+        underlineView.alpha = underlineViewAlphaDefault
         addToolbar()
     }
     
@@ -104,13 +104,13 @@ class BasePicker: PlaceholderedTextField {
     }
     
     @IBAction func textFieldEditingDidBegin(_ sender: UITextField) {
-        underlineView.alpha = kUnderlineViewAlphaHighlighted
-        underlineViewHeight.constant = kUnderlineViewHeightHighlighted
+        underlineView.alpha = underlineViewAlphaHighlighted
+        underlineViewHeight.constant = underlineViewHeightHighlighted
     }
     
     @IBAction func textFieldEditingDidEnd(_ sender: UITextField) {
-        underlineView.alpha = kUnderlineViewAlphaDefault
-        underlineViewHeight.constant = kUnderlineViewHeightDefault
+        underlineView.alpha = underlineViewAlphaDefault
+        underlineViewHeight.constant = underlineViewHeightDefault
     }
 }
 

--- a/ShopApp/App/Modules/Base/Views/BasePicker/BasePicker.swift
+++ b/ShopApp/App/Modules/Base/Views/BasePicker/BasePicker.swift
@@ -110,7 +110,7 @@ class BasePicker: PlaceholderedTextField {
     
     @IBAction func textFieldEditingDidEnd(_ sender: UITextField) {
         underlineView.alpha = underlineViewAlphaDefault
-        underlineViewHeight.constant = underlineViewHeightDefault
+        underlineViewHeight.constant = underlineViewHeightDefault        
     }
 }
 

--- a/ShopApp/App/Modules/Base/Views/BasePicker/BasePicker.xib
+++ b/ShopApp/App/Modules/Base/Views/BasePicker/BasePicker.xib
@@ -10,7 +10,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BasePicker" customModule="ShopClient" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BasePicker" customModule="ShopApp" customModuleProvider="target">
             <connections>
                 <outlet property="placeholderLabel" destination="Bbz-4N-VKt" id="yic-vb-AVM"/>
                 <outlet property="placeholderVerticallyConstraint" destination="yOc-Pu-4L2" id="3as-KB-sjZ"/>
@@ -29,6 +29,9 @@
                     <nil key="textColor"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                     <textInputTraits key="textInputTraits"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="text"/>
+                    </userDefinedRuntimeAttributes>
                     <connections>
                         <action selector="textFieldEditingDidBegin:" destination="-1" eventType="editingDidBegin" id="j4H-v3-hHj"/>
                         <action selector="textFieldEditingDidEnd:" destination="-1" eventType="editingDidEnd" id="pE6-MI-YH6"/>
@@ -47,6 +50,9 @@
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="wSx-w1-UAS"/>
                     </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="underline"/>
+                    </userDefinedRuntimeAttributes>
                 </view>
                 <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="82i-pE-5B0" userLabel="Placeholder View">
                     <rect key="frame" x="0.0" y="11" width="223" height="30"/>
@@ -56,6 +62,9 @@
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="placeholder"/>
+                            </userDefinedRuntimeAttributes>
                         </label>
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/ShopApp/App/Modules/Base/Views/ErrorView/ErrorView.xib
+++ b/ShopApp/App/Modules/Base/Views/ErrorView/ErrorView.xib
@@ -11,7 +11,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ErrorView" customModule="ShopClient" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ErrorView" customModule="ShopApp" customModuleProvider="target">
             <connections>
                 <outlet property="errorImageView" destination="aXQ-jJ-eL2" id="msw-RU-8Gr"/>
                 <outlet property="errorTextLabel" destination="T0m-Dg-Z0e" id="XiZ-Vz-PqR"/>
@@ -28,6 +28,9 @@
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="errorText"/>
+                    </userDefinedRuntimeAttributes>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VSi-2c-9yV">
                     <rect key="frame" x="129" y="255.5" width="90" height="30"/>
@@ -35,6 +38,9 @@
                         <constraint firstAttribute="width" constant="90" id="w4b-mo-X0J"/>
                     </constraints>
                     <state key="normal" title="Try again"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="tryAgain"/>
+                    </userDefinedRuntimeAttributes>
                     <connections>
                         <action selector="tryAgainButtonDidTap:" destination="-1" eventType="touchUpInside" id="XuE-0b-fJ0"/>
                     </connections>
@@ -45,6 +51,10 @@
                     <constraints>
                         <constraint firstAttribute="width" secondItem="aXQ-jJ-eL2" secondAttribute="height" multiplier="1:1" id="KZG-Zn-71J"/>
                     </constraints>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityLabel" value="errorImage"/>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="isAccessibilityView" value="YES"/>
+                    </userDefinedRuntimeAttributes>
                 </imageView>
             </subviews>
             <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>

--- a/ShopApp/App/Modules/Base/Views/LoadingView/LoadingView.swift
+++ b/ShopApp/App/Modules/Base/Views/LoadingView/LoadingView.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 class LoadingView: UIView {
+    
     // MARK: - View lifecycle
     
     override init(frame: CGRect) {

--- a/ShopApp/App/Modules/Base/Views/PlaceholderedTextField/PlaceholderedTextField.swift
+++ b/ShopApp/App/Modules/Base/Views/PlaceholderedTextField/PlaceholderedTextField.swift
@@ -8,17 +8,17 @@
 
 import UIKit
 
-private let kPlaceholderAnimationDuration: TimeInterval = 0.15
-private let kPlaceholderPositionTopY: CGFloat = -25
-private let kPlaceholderFontSizeTop: CGFloat = 11
-private let kPlaceholderFontSizeDefault: CGFloat = 12
-private let kPlaceholderColorTop = UIColor.black.withAlphaComponent(0.5)
-
 class PlaceholderedTextField: TextFieldWrapper {
     // swiftlint:disable private_outlet
     @IBOutlet fileprivate(set) weak var placeholderLabel: UILabel!
     @IBOutlet fileprivate(set) weak var placeholderVerticallyConstraint: NSLayoutConstraint!
     // swiftlint:enable private_outlet
+    
+    private let placeholderAnimationDuration: TimeInterval = 0.15
+    private let placeholderPositionTopY: CGFloat = -25
+    private let placeholderFontSizeTop: CGFloat = 11
+    private let placeholderFontSizeDefault: CGFloat = 12
+    private let placeholderColorTop = UIColor.black.withAlphaComponent(0.5)
     
     var placeholder: String? {
         didSet {
@@ -34,10 +34,10 @@ class PlaceholderedTextField: TextFieldWrapper {
     }
     
     func updatePlaceholderPosition(toTop: Bool, animated: Bool) {
-        let animationDuration = animated ? kPlaceholderAnimationDuration : 0
-        let placeholderVerticalPosition: CGFloat = toTop ? kPlaceholderPositionTopY : 0
+        let animationDuration = animated ? placeholderAnimationDuration : 0
+        let placeholderVerticalPosition: CGFloat = toTop ? placeholderPositionTopY : 0
         placeholderVerticallyConstraint?.constant = placeholderVerticalPosition
-        let fontSize = toTop ? kPlaceholderFontSizeTop : kPlaceholderFontSizeDefault
+        let fontSize = toTop ? placeholderFontSizeTop : placeholderFontSizeDefault
         placeholderLabel.font = .systemFont(ofSize: fontSize)
         
         UIView.animate(withDuration: animationDuration) {
@@ -45,7 +45,7 @@ class PlaceholderedTextField: TextFieldWrapper {
         }
         
         UIView.transition(with: placeholderLabel, duration: animationDuration, options: .transitionCrossDissolve, animations: {
-            self.placeholderLabel?.textColor = toTop ? kPlaceholderColorTop : .black
+            self.placeholderLabel.textColor = toTop ? self.placeholderColorTop : .black
         })
     }
 }

--- a/ShopAppTests/App/Account/Controllers/ChangePasswordViewControllerSpec.swift
+++ b/ShopAppTests/App/Account/Controllers/ChangePasswordViewControllerSpec.swift
@@ -35,20 +35,20 @@ class ChangePasswordViewControllerSpec: QuickSpec {
             }
             
             it("should have a title with correct text") {
-                expect(viewController.title).to(equal("ControllerTitle.SetNewPassword".localizable))
+                expect(viewController.title) == "ControllerTitle.SetNewPassword".localizable
             }
             
             it("should have a close button") {
-                expect(viewController.navigationItem.rightBarButtonItem?.image).to(equal(#imageLiteral(resourceName: "cross")))
+                expect(viewController.navigationItem.rightBarButtonItem?.image) == #imageLiteral(resourceName: "cross")
             }
             
             it("should have text filed views with correct placeholders") {
-                expect(newPasswordTextFieldView.placeholder).to(equal("Placeholder.NewPassword".localizable.required.uppercased()))
-                expect(confirmPasswordTextFieldView.placeholder).to(equal("Placeholder.ConfirmPassword".localizable.required.uppercased()))
+                expect(newPasswordTextFieldView.placeholder) == "Placeholder.NewPassword".localizable.required.uppercased()
+                expect(confirmPasswordTextFieldView.placeholder) == "Placeholder.ConfirmPassword".localizable.required.uppercased()
             }
             
             it("should have an update button with correct title") {
-                expect(updateButton.title(for: .normal)).to(equal("Button.Update".localizable.uppercased()))
+                expect(updateButton.title(for: .normal)) == "Button.Update".localizable.uppercased()
             }
         }
         
@@ -71,7 +71,7 @@ class ChangePasswordViewControllerSpec: QuickSpec {
                     
                     viewController.viewModel.updateButtonEnabled
                         .subscribe(onNext: { _ in
-                            expect(updateButton.isEnabled).toEventually(beTrue())
+                            expect(updateButton.isEnabled) == true
                         })
                         .disposed(by: disposeBag)
                 }
@@ -84,7 +84,7 @@ class ChangePasswordViewControllerSpec: QuickSpec {
                     
                     viewController.viewModel.updateButtonEnabled
                         .subscribe(onNext: { _ in
-                            expect(updateButton.isEnabled).toEventually(beFalse())
+                            expect(updateButton.isEnabled) == false
                         })
                         .disposed(by: disposeBag)
                 }

--- a/ShopAppTests/App/Account/ViewModels/ChangePasswordViewModelSpec.swift
+++ b/ShopAppTests/App/Account/ViewModels/ChangePasswordViewModelSpec.swift
@@ -25,8 +25,8 @@ class ChangePasswordViewModelSpec: QuickSpec {
         
         describe("when view model initialized") {
             it("should have variables with a correct initial values") {
-                expect(viewModel.newPasswordText.value).to(equal(""))
-                expect(viewModel.confirmPasswordText.value).to(equal(""))
+                expect(viewModel.newPasswordText.value) == ""
+                expect(viewModel.confirmPasswordText.value) == ""
             }
         }
         
@@ -46,7 +46,7 @@ class ChangePasswordViewModelSpec: QuickSpec {
                     
                     viewModel.updateButtonEnabled
                         .subscribe(onNext: { enabled in
-                            expect(enabled).toEventually(beTrue())
+                            expect(enabled) == true
                         })
                         .disposed(by: disposeBag)
                 }
@@ -58,7 +58,7 @@ class ChangePasswordViewModelSpec: QuickSpec {
                     
                     viewModel.updateButtonEnabled
                         .subscribe(onNext: { enabled in
-                            expect(enabled).toEventually(beFalse())
+                            expect(enabled) == false
                         })
                         .disposed(by: disposeBag)
                 }

--- a/ShopAppTests/App/Base/Controllers/BaseCollectionViewControllerSpec.swift
+++ b/ShopAppTests/App/Base/Controllers/BaseCollectionViewControllerSpec.swift
@@ -32,7 +32,7 @@ class BaseCollectionViewControllerSpec: QuickSpec {
                 viewController.refreshControl?.beginRefreshing()
                 viewController.stopLoadAnimating()
                 
-                expect(viewController.refreshControl?.isRefreshing).to(beFalse())
+                expect(viewController.refreshControl?.isRefreshing) == false
             }
         }
     }

--- a/ShopAppTests/App/Base/Controllers/BaseTableViewControllerSpec.swift
+++ b/ShopAppTests/App/Base/Controllers/BaseTableViewControllerSpec.swift
@@ -32,7 +32,7 @@ class BaseTableViewControllerSpec: QuickSpec {
                 viewController.refreshControl?.beginRefreshing()
                 viewController.stopLoadAnimating()
                 
-                expect(viewController.refreshControl?.isRefreshing).to(beFalse())
+                expect(viewController.refreshControl?.isRefreshing) == false
             }
         }
     }

--- a/ShopAppTests/App/Base/Controllers/BaseViewControllerSpec.swift
+++ b/ShopAppTests/App/Base/Controllers/BaseViewControllerSpec.swift
@@ -191,7 +191,7 @@ class BaseViewControllerSpec: QuickSpec {
                             })
                             .disposed(by: disposeBag)
                         
-                        let error = CriticalError.init(with: nil, message: "")
+                        let error = CriticalError(with: nil, message: "")
                         let state = ViewState.error(error: error)
                         viewController.viewModel.state.onNext(state)
                     }

--- a/ShopAppTests/App/Base/Controllers/BaseViewControllerSpec.swift
+++ b/ShopAppTests/App/Base/Controllers/BaseViewControllerSpec.swift
@@ -34,7 +34,7 @@ class BaseViewControllerSpec: QuickSpec {
             }
             
             it("should have correct offset in toast view's appearance") {
-                expect(ToastView.appearance().bottomOffsetPortrait).to(equal(80))
+                expect(ToastView.appearance().bottomOffsetPortrait) == 80
             }
         }
         
@@ -171,7 +171,7 @@ class BaseViewControllerSpec: QuickSpec {
                             .subscribe(onNext: { _ in
                                 expect(viewController.view.subviews.contains(viewController.loadingView)).toEventually(beFalse())
                                 expect(viewController.view.subviews.contains(viewController.errorView)).toEventually(beFalse())
-                                expect(ToastCenter.default.currentToast).toNotEventually(beNil())
+                                expect(ToastCenter.default.currentToast).toEventuallyNot(beNil())
                             })
                             .disposed(by: disposeBag)
                         
@@ -187,7 +187,7 @@ class BaseViewControllerSpec: QuickSpec {
                             .subscribe(onNext: { _ in
                                 expect(viewController.view.subviews.contains(viewController.loadingView)).toEventually(beFalse())
                                 expect(viewController.view.subviews.contains(viewController.errorView)).toEventually(beFalse())
-                                expect(ToastCenter.default.currentToast).toNotEventually(beNil())
+                                expect(ToastCenter.default.currentToast).toEventuallyNot(beNil())
                             })
                             .disposed(by: disposeBag)
                         

--- a/ShopAppTests/App/Base/Controllers/NavigationControllerSpec.swift
+++ b/ShopAppTests/App/Base/Controllers/NavigationControllerSpec.swift
@@ -23,19 +23,19 @@ class NavigationControllerSpec: QuickSpec {
         
         describe("when view loaded") {
             it("should have correct tint colors in navigation bar") {
-                expect(navigationController.navigationBar.tintColor).to(equal(.black))
-                expect(navigationController.navigationBar.barTintColor).to(equal(.white))
+                expect(navigationController.navigationBar.tintColor) == .black
+                expect(navigationController.navigationBar.barTintColor) == .white
             }
             
             it("should have correct images in navigation bar") {
                 let shadowImage = UIImage.add_image(with: Colors.shadowImage)
                 let backgroundImage = UIImage.add_image(with: .white)
-                expect(navigationController.navigationBar.shadowImage).to(equal(shadowImage))
-                expect(navigationController.navigationBar.backgroundImage(for: .default)).to(equal(backgroundImage))
+                expect(navigationController.navigationBar.shadowImage) == shadowImage
+                expect(navigationController.navigationBar.backgroundImage(for: .default)) == backgroundImage
             }
             
             it("should have correct translucency in navigation bar") {
-                expect(navigationController.navigationBar.isTranslucent).to(beFalse())
+                expect(navigationController.navigationBar.isTranslucent) == false
             }
         }
     }

--- a/ShopAppTests/App/Base/Controllers/TabBarControllerSpec.swift
+++ b/ShopAppTests/App/Base/Controllers/TabBarControllerSpec.swift
@@ -25,8 +25,8 @@ class TabBarControllerSpec: QuickSpec {
             it("should have correct images in tab bar's appearance") {
                 let shadowImage = UIImage.add_image(with: Colors.shadowImage)
                 let backgroundImage = UIImage.add_image(with: Colors.barBackground)
-                expect(UITabBar.appearance().shadowImage).to(equal(shadowImage))
-                expect(UITabBar.appearance().backgroundImage).to(equal(backgroundImage))
+                expect(UITabBar.appearance().shadowImage) == shadowImage
+                expect(UITabBar.appearance().backgroundImage) == backgroundImage
             }
         }
     }

--- a/ShopAppTests/App/Base/ViewModels/GridCollectionViewModelSpec.swift
+++ b/ShopAppTests/App/Base/ViewModels/GridCollectionViewModelSpec.swift
@@ -23,7 +23,7 @@ class GridCollectionViewModelSpec: QuickSpec {
         
         describe("when view model initialized") {
             it("should have variable with a correct initial value") {
-                expect(viewModel.products.value.isEmpty).to(beTrue())
+                expect(viewModel.products.value.isEmpty) == true
             }
         }
         
@@ -36,7 +36,7 @@ class GridCollectionViewModelSpec: QuickSpec {
                     viewModel.products.value = products
                     viewModel.updateProducts(products: products)
                 
-                    expect(viewModel.products.value.count).to(equal(1))
+                    expect(viewModel.products.value.count) == 1
                 }
             }
             
@@ -46,7 +46,7 @@ class GridCollectionViewModelSpec: QuickSpec {
                     viewModel.products.value = products
                     viewModel.updateProducts(products: products)
 
-                    expect(viewModel.products.value.count).to(equal(2))
+                    expect(viewModel.products.value.count) == 2
                 }
             }
         }

--- a/ShopAppTests/App/Base/Views/BasePickerSpec.swift
+++ b/ShopAppTests/App/Base/Views/BasePickerSpec.swift
@@ -1,0 +1,131 @@
+//
+//  BasePickerSpec.swift
+//  ShopAppTests
+//
+//  Created by Radyslav Krechet on 2/21/18.
+//  Copyright © 2018 RubyGarage. All rights reserved.
+//
+
+import Nimble
+import Quick
+
+@testable import ShopApp
+
+class BasePickerSpec: QuickSpec {
+    override func spec() {
+        var view: BasePicker!
+        var textField: UITextField!
+        var placeholderLabel: UILabel!
+        var underlineView: UIView!
+        
+        beforeEach {
+            view = BasePicker()
+            
+            textField = self.findView(withAccessibilityLabel: "text", in: view) as! UITextField
+            placeholderLabel = self.findView(withAccessibilityLabel: "placeholder", in: view) as! UILabel
+            underlineView = self.findView(withAccessibilityLabel: "underline", in: view)
+        }
+        
+        describe("") {
+            it("") {
+                expect(view.pickerView.backgroundColor) == .white
+                expect(view.pickerView.numberOfComponents) == 1
+                expect(view.pickerView.numberOfRows(inComponent: 0)) == 0
+            }
+            
+            it("") {
+                expect(textField.tintColor) == .clear
+                expect(textField.inputView) === view.pickerView
+            }
+            
+            it("") {
+                expect(placeholderLabel.text) == ""
+            }
+            
+            it("") {
+                expect(underlineView.alpha) ≈ 0.2
+            }
+            
+            it("") {
+                let toolBar = textField.inputAccessoryView as! UIToolbar
+                
+                expect(toolBar.barStyle.rawValue) == UIBarStyle.default.rawValue
+                expect(toolBar.isTranslucent) == false
+                expect(toolBar.backgroundColor) == .white
+                expect(toolBar.tintColor) == .black
+                expect(toolBar.items?.last?.title) == "Button.Done".localizable
+                expect(toolBar.isUserInteractionEnabled) == true
+            }
+        }
+        
+        describe("") {
+            context("") {
+                it("") {
+                    view.text = nil
+                    view.customData = ["first"]
+                    
+                    expect(view.pickerView.numberOfRows(inComponent: 0)) == 1
+                    expect(view.pickerView.selectedRow(inComponent: 0)) == 0
+                }
+            }
+            
+            context("") {
+                it("") {
+                    view.text = "second"
+                    view.customData = ["first", "second"]
+                    
+                    expect(view.pickerView.numberOfRows(inComponent: 0)) == 2
+                    expect(view.pickerView.selectedRow(inComponent: 0)) == 1
+                }
+            }
+        }
+        
+        describe("") {
+            it("") {
+                view.customData = ["first", "second"]
+                view.text = "second"
+                
+                expect(view.pickerView.selectedRow(inComponent: 0)) == 1
+            }
+        }
+        
+        describe("") {
+            beforeEach {
+                textField.sendActions(for: .editingDidBegin)
+            }
+            
+            context("") {
+                it("") {
+                    view.layoutIfNeeded() // calls layoutSubviews, that calls updateConstraintsIfNeeded
+                    
+                    expect(underlineView.alpha) == 1
+                    expect(underlineView.frame.size.height) == 2
+                }
+            }
+            
+            context("") {
+                it("") {
+                    textField.sendActions(for: .editingDidEnd)
+                    view.layoutIfNeeded() // calls layoutSubviews, that calls updateConstraintsIfNeeded
+                    
+                    expect(underlineView.alpha) ≈ 0.2
+                    expect(underlineView.frame.size.height) == 1
+                }
+            }
+        }
+        
+        describe("") {
+            it("") {
+                view.text = "second"
+                view.customData = ["first", "second"]
+                
+                let toolBar = textField.inputAccessoryView as! UIToolbar
+                let doneItem = toolBar.items?.last
+                view.perform(doneItem?.action)
+                
+                expect(textField.text) == "second"
+                expect(textField.isEditing) == false
+            }
+        }
+    }
+}

--- a/ShopAppTests/App/Base/Views/BasePickerSpec.swift
+++ b/ShopAppTests/App/Base/Views/BasePickerSpec.swift
@@ -26,27 +26,27 @@ class BasePickerSpec: QuickSpec {
             underlineView = self.findView(withAccessibilityLabel: "underline", in: view)
         }
         
-        describe("") {
-            it("") {
+        describe("when view initialized") {
+            it("should have correct picker view") {
                 expect(view.pickerView.backgroundColor) == .white
                 expect(view.pickerView.numberOfComponents) == 1
                 expect(view.pickerView.numberOfRows(inComponent: 0)) == 0
             }
             
-            it("") {
+            it("should have correct text filed") {
                 expect(textField.tintColor) == .clear
                 expect(textField.inputView) === view.pickerView
             }
             
-            it("") {
+            it("should have correct placeholder") {
                 expect(placeholderLabel.text) == ""
             }
             
-            it("") {
+            it("should have correct underline view") {
                 expect(underlineView.alpha) ≈ 0.2
             }
             
-            it("") {
+            it("should have correct tool bar for text field") {
                 let toolBar = textField.inputAccessoryView as! UIToolbar
                 
                 expect(toolBar.barStyle.rawValue) == UIBarStyle.default.rawValue
@@ -58,9 +58,9 @@ class BasePickerSpec: QuickSpec {
             }
         }
         
-        describe("") {
-            context("") {
-                it("") {
+        describe("when custom data set") {
+            context("if it haven't text") {
+                it("needs to update picker components") {
                     view.text = nil
                     view.customData = ["first"]
                     
@@ -69,8 +69,8 @@ class BasePickerSpec: QuickSpec {
                 }
             }
             
-            context("") {
-                it("") {
+            context("if it have text") {
+                it("needs to update picker components and select needed row") {
                     view.text = "second"
                     view.customData = ["first", "second"]
                     
@@ -80,22 +80,35 @@ class BasePickerSpec: QuickSpec {
             }
         }
         
-        describe("") {
-            it("") {
+        describe("when text changed") {
+            beforeEach {
                 view.customData = ["first", "second"]
-                view.text = "second"
-                
-                expect(view.pickerView.selectedRow(inComponent: 0)) == 1
+            }
+            
+            context("if it haven't text in data") {
+                it("needs to select first row") {
+                    view.text = "third"
+                    
+                    expect(view.pickerView.selectedRow(inComponent: 0)) == 0
+                }
+            }
+            
+            context("if it have text in data") {
+                it("needs to select needed row") {
+                    view.text = "second"
+                    
+                    expect(view.pickerView.selectedRow(inComponent: 0)) == 1
+                }
             }
         }
         
-        describe("") {
+        describe("when text field editing changed") {
             beforeEach {
                 textField.sendActions(for: .editingDidBegin)
             }
             
-            context("") {
-                it("") {
+            context("if it have to begin") {
+                it("needs to setup underline view") {
                     view.layoutIfNeeded() // calls layoutSubviews, that calls updateConstraintsIfNeeded
                     
                     expect(underlineView.alpha) == 1
@@ -103,8 +116,8 @@ class BasePickerSpec: QuickSpec {
                 }
             }
             
-            context("") {
-                it("") {
+            context("if it have to end") {
+                it("needs to setup underline view") {
                     textField.sendActions(for: .editingDidEnd)
                     view.layoutIfNeeded() // calls layoutSubviews, that calls updateConstraintsIfNeeded
                     
@@ -114,10 +127,10 @@ class BasePickerSpec: QuickSpec {
             }
         }
         
-        describe("") {
-            it("") {
-                view.text = "second"
+        describe("when done pressed") {
+            it("needs to setup text field") {
                 view.customData = ["first", "second"]
+                view.pickerView.selectRow(1, inComponent: 0, animated: false)
                 
                 let toolBar = textField.inputAccessoryView as! UIToolbar
                 let doneItem = toolBar.items?.last

--- a/ShopAppTests/App/Base/Views/ErrorViewSpec.swift
+++ b/ShopAppTests/App/Base/Views/ErrorViewSpec.swift
@@ -28,36 +28,30 @@ class ErrorViewSpec: QuickSpec {
         }
         
         describe("") {
-            it("") {
-                view.error = NetworkError()
-                expect(errorImageView.isHidden) == false
-                expect(errorTextLabel.text) == "Error.Unknown".localizable
+            context("") {
+                it("") {
+                    view.error = NetworkError()
+                    expect(errorImageView.isHidden) == false
+                    expect(errorTextLabel.text) == "Error.Unknown".localizable
+                }
             }
             
-            it("") {
-                view.error = RepoError()
-                expect(errorImageView.isHidden) == true
-                expect(errorTextLabel.text) == "Error.NoConnection".localizable
+            context("") {
+                it("") {
+                    view.error = RepoError()
+                    expect(errorImageView.isHidden) == true
+                    expect(errorTextLabel.text) == "Error.NoConnection".localizable
+                }
             }
         }
         
         describe("") {
             it("") {
-                class DelegateMock: ErrorViewDelegate {
-                    private var view: ErrorView!
-                    
-                    init(view: ErrorView) {
-                        self.view = view
-                    }
-                    
-                    func viewDidTapTryAgain(_ view: ErrorView) {
-                        expect(view) === self.view
-                    }
-                }
-                
-                let delegateMock = DelegateMock(view: view)
+                let delegateMock = ErrorViewDelegateMock()
                 view.delegate = delegateMock
                 tryAgainButton.sendActions(for: .touchUpInside)
+                
+                expect(delegateMock.view) === view
             }
         }
     }

--- a/ShopAppTests/App/Base/Views/ErrorViewSpec.swift
+++ b/ShopAppTests/App/Base/Views/ErrorViewSpec.swift
@@ -1,0 +1,64 @@
+//
+//  ErrorViewSpec.swift
+//  ShopAppTests
+//
+//  Created by Radyslav Krechet on 2/20/18.
+//  Copyright © 2018 RubyGarage. All rights reserved.
+//
+
+import Nimble
+import Quick
+import ShopApp_Gateway
+
+@testable import ShopApp
+
+class ErrorViewSpec: QuickSpec {
+    override func spec() {
+        var view: ErrorView!
+        var errorTextLabel: UILabel!
+        var errorImageView: UIImageView!
+        var tryAgainButton: UIButton!
+        
+        beforeEach {
+            view = ErrorView(frame: UIScreen.main.bounds)
+            
+            errorTextLabel = self.findView(withAccessibilityLabel: "errorText", in: view) as! UILabel
+            errorImageView = self.findView(withAccessibilityLabel: "errorImage", in: view) as! UIImageView
+            tryAgainButton = self.findView(withAccessibilityLabel: "tryAgain", in: view) as! UIButton
+        }
+        
+        describe("") {
+            it("") {
+                view.error = NetworkError()
+                expect(errorImageView.isHidden).to(beFalse())
+                expect(errorTextLabel.text).to(equal("Error.Unknown".localizable))
+            }
+            
+            it("") {
+                view.error = RepoError()
+                expect(errorImageView.isHidden).to(beTrue())
+                expect(errorTextLabel.text).to(equal("Error.NoConnection".localizable))
+            }
+        }
+        
+        describe("") {
+            it("") {
+                class DelegateMock: ErrorViewDelegate {
+                    private var view: ErrorView!
+                    
+                    init(view: ErrorView) {
+                        self.view = view
+                    }
+                    
+                    func viewDidTapTryAgain(_ view: ErrorView) {
+                        expect(view).toEventually(equal(self.view))
+                    }
+                }
+                
+                let delegateMock = DelegateMock(view: view)
+                view.delegate = delegateMock
+                tryAgainButton.sendActions(for: .touchUpInside)
+            }
+        }
+    }
+}

--- a/ShopAppTests/App/Base/Views/ErrorViewSpec.swift
+++ b/ShopAppTests/App/Base/Views/ErrorViewSpec.swift
@@ -30,14 +30,14 @@ class ErrorViewSpec: QuickSpec {
         describe("") {
             it("") {
                 view.error = NetworkError()
-                expect(errorImageView.isHidden).to(beFalse())
-                expect(errorTextLabel.text).to(equal("Error.Unknown".localizable))
+                expect(errorImageView.isHidden) == false
+                expect(errorTextLabel.text) == "Error.Unknown".localizable
             }
             
             it("") {
                 view.error = RepoError()
-                expect(errorImageView.isHidden).to(beTrue())
-                expect(errorTextLabel.text).to(equal("Error.NoConnection".localizable))
+                expect(errorImageView.isHidden) == true
+                expect(errorTextLabel.text) == "Error.NoConnection".localizable
             }
         }
         
@@ -51,7 +51,7 @@ class ErrorViewSpec: QuickSpec {
                     }
                     
                     func viewDidTapTryAgain(_ view: ErrorView) {
-                        expect(view).toEventually(equal(self.view))
+                        expect(view) === self.view
                     }
                 }
                 

--- a/ShopAppTests/App/Base/Views/ErrorViewSpec.swift
+++ b/ShopAppTests/App/Base/Views/ErrorViewSpec.swift
@@ -27,17 +27,17 @@ class ErrorViewSpec: QuickSpec {
             tryAgainButton = self.findView(withAccessibilityLabel: "tryAgain", in: view) as! UIButton
         }
         
-        describe("") {
-            context("") {
-                it("") {
+        describe("when error set") {
+            context("with type network") {
+                it("needs to hide image and setup text") {
                     view.error = NetworkError()
                     expect(errorImageView.isHidden) == false
                     expect(errorTextLabel.text) == "Error.Unknown".localizable
                 }
             }
             
-            context("") {
-                it("") {
+            context("with type not network") {
+                it("needs to show image and setup text") {
                     view.error = RepoError()
                     expect(errorImageView.isHidden) == true
                     expect(errorTextLabel.text) == "Error.NoConnection".localizable
@@ -45,8 +45,8 @@ class ErrorViewSpec: QuickSpec {
             }
         }
         
-        describe("") {
-            it("") {
+        describe("when try again pressed") {
+            it("needs to perform delegate method") {
                 let delegateMock = ErrorViewDelegateMock()
                 view.delegate = delegateMock
                 tryAgainButton.sendActions(for: .touchUpInside)

--- a/ShopAppTests/App/Base/Views/Mocks/ErrorViewDelegateMock.swift
+++ b/ShopAppTests/App/Base/Views/Mocks/ErrorViewDelegateMock.swift
@@ -1,0 +1,19 @@
+//
+//  ErrorViewDelegateMock.swift
+//  ShopAppTests
+//
+//  Created by Radyslav Krechet on 2/21/18.
+//  Copyright © 2018 RubyGarage. All rights reserved.
+//
+
+import ShopApp_Gateway
+
+@testable import ShopApp
+
+class ErrorViewDelegateMock: ErrorViewDelegate {
+    var view: ErrorView?
+    
+    func viewDidTapTryAgain(_ view: ErrorView) {
+        self.view = view
+    }
+}


### PR DESCRIPTION
There are no tests for `PlaceholderedTextField` and `TextFieldWrapper` that are base and have private outlets. Also, there are no tests for `LoadingView`. Let me know if you not agree with that and we need some specific tests for one or few of these classes.

FYI: Tests for base provider (grid) will be implement in next PR.